### PR TITLE
fix: cachecontrol uses the deprecated utcnow method

### DIFF
--- a/cacheyou/caches/redis_cache.py
+++ b/cacheyou/caches/redis_cache.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cacheyou.cache import BaseCache
 
@@ -19,7 +19,10 @@ class RedisCache(BaseCache):
         if not expires:
             self.conn.set(key, value)
         elif isinstance(expires, datetime):
-            expires = expires - datetime.utcnow()
+            now_utc = datetime.now(timezone.utc)
+            if expires.tzinfo is None:
+                now_utc = now_utc.replace(tzinfo=None)
+            expires = expires - now_utc
             self.conn.setex(key, int(expires.total_seconds()), value)
         else:
             self.conn.setex(key, expires, value)

--- a/cacheyou/heuristics.py
+++ b/cacheyou/heuristics.py
@@ -4,14 +4,14 @@
 
 import calendar
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from email.utils import formatdate, parsedate, parsedate_tz
 
 TIME_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
 
 def expire_after(delta, date=None):
-    date = date or datetime.utcnow()
+    date = date or datetime.now(timezone.utc)
     return date + delta
 
 
@@ -63,7 +63,7 @@ class OneDayCache(BaseHeuristic):
 
         if "expires" not in response.headers:
             date = parsedate(response.headers["date"])
-            expires = expire_after(timedelta(days=1), date=datetime(*date[:6]))
+            expires = expire_after(timedelta(days=1), date=datetime(*date[:6], tzinfo=timezone.utc))
             headers["expires"] = datetime_to_header(expires)
             headers["cache-control"] = "public"
         return headers

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -4,7 +4,7 @@
 
 import calendar
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from email.utils import formatdate, parsedate
 from pprint import pprint
 from unittest.mock import Mock
@@ -157,7 +157,8 @@ class TestModifiedUnitTests:
         resp = DummyResponse(200, {"Date": self.now, "Last-Modified": self.week_ago})
         modified = self.heuristic.update_headers(resp)
         assert ["expires"] == list(modified.keys())
-        assert datetime(*parsedate(modified["expires"])[:6]) > datetime.now()
+        expected = datetime(*parsedate(modified["expires"])[:6], tzinfo=timezone.utc)
+        assert expected > datetime.now(timezone.utc)
 
     def test_last_modified_is_not_used_when_cache_control_present(self):
         resp = DummyResponse(
@@ -185,7 +186,8 @@ class TestModifiedUnitTests:
         )
         modified = self.heuristic.update_headers(resp)
         assert ["expires"] == list(modified.keys())
-        assert datetime(*parsedate(modified["expires"])[:6]) > datetime.now()
+        expected = datetime(*parsedate(modified["expires"])[:6], tzinfo=timezone.utc)
+        assert expected > datetime.now(timezone.utc)
 
     def test_warning_not_added_when_response_more_recent_than_24_hours(self):
         resp = DummyResponse(200, {"Date": self.now, "Last-Modified": self.week_ago})

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import Mock
 
 from cacheyou.caches import RedisCache
@@ -15,6 +15,10 @@ class TestRedisCache:
 
     def test_set_expiration_datetime(self):
         self.cache.set("foo", "bar", expires=datetime(2014, 2, 2))
+        assert self.conn.setex.called
+
+    def test_set_expiration_datetime_aware(self):
+        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2, tzinfo=timezone.utc))
         assert self.conn.setex.called
 
     def test_set_expiration_int(self):


### PR DESCRIPTION
Fixes #291

Signed-off-by: Frost Ming <me@frostming.com>